### PR TITLE
fix: handle missing attribute in habit progress

### DIFF
--- a/src/context/DataContext.jsx
+++ b/src/context/DataContext.jsx
@@ -144,26 +144,32 @@ function dataReducer(state, action) {
         if (shouldAwardPoints) {
             const basePoints = { xp: 115, coins: 8 };
             const attribute = newState.attributes.find(attr => attr.id === attributeIdToReward);
-            newState.attributes = newState.attributes.map(attr => {
-                if (attr.id === attributeIdToReward) {
-                   let newXp = attr.xp + basePoints.xp;
-                    let newLevel = attr.level;
-                    let xpToNext = attr.xpToNextLevel;
-                    while (newXp >= xpToNext) {
-                        newXp -= xpToNext;
-                        newLevel++;
-                        xpToNext = calculateXpToNextLevel(newLevel);
-                        newState.leveledUpAttributeId = attr.id;
-                        newState.toastInfo = { message: `LEVEL UP! Nível ${newLevel} em ${attr.name.split(' ')[1]}`, icon: '🎉'};
+
+            if (attribute) {
+                newState.attributes = newState.attributes.map(attr => {
+                    if (attr.id === attributeIdToReward) {
+                        let newXp = attr.xp + basePoints.xp;
+                        let newLevel = attr.level;
+                        let xpToNext = attr.xpToNextLevel;
+                        while (newXp >= xpToNext) {
+                            newXp -= xpToNext;
+                            newLevel++;
+                            xpToNext = calculateXpToNextLevel(newLevel);
+                            newState.leveledUpAttributeId = attr.id;
+                            newState.toastInfo = { message: `LEVEL UP! Nível ${newLevel} em ${attr.name.split(' ')[1]}`, icon: '🎉'};
+                        }
+                        return { ...attr, xp: newXp, level: newLevel, xpToNextLevel: xpToNext };
                     }
-                    return { ...attr, xp: newXp, level: newLevel, xpToNextLevel: xpToNext };
+                    return attr;
+                });
+                if (!newState.toastInfo) {
+                    newState.toastInfo = { message: `Hábito Completo!`, icon: attribute.name.split(' ')[0] };
                 }
-                return attr;
-            });
-            newState.user = { ...newState.user, coins: newState.user.coins + basePoints.coins };
-             if (!newState.toastInfo) {
-                newState.toastInfo = { message: `Hábito Completo!`, icon: attribute.name.split(' ')[0]};
+            } else {
+                newState.toastInfo = { message: `Hábito Completo!`, icon: '✅' };
             }
+
+            newState.user = { ...newState.user, coins: newState.user.coins + basePoints.coins };
         }
         return newState;
     }


### PR DESCRIPTION
## Summary
- avoid awarding XP when linked attribute is missing
- show default toast when no attribute found

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68c5a7da81b0832f9d5395a5d3d11407