### PR TITLE
Recalculate task completion when toggling subtasks

### DIFF
--- a/src/context/DataContext.jsx
+++ b/src/context/DataContext.jsx
@@ -70,7 +70,6 @@ function dataReducer(state, action) {
 
     case 'TOGGLE_SUBTASK': {
         const { taskId, subtaskId } = action.payload;
-        let taskCompleted = false;
         let attributeIdToReward = null;
         let newState = { ...state };
 
@@ -81,16 +80,18 @@ function dataReducer(state, action) {
                 );
                 const allSubtasksCompleted = newSubtasks.every(st => st.completed);
                 if (allSubtasksCompleted && !task.completed) {
-                    taskCompleted = true;
                     attributeIdToReward = task.linkedAttribute;
                     return { ...task, subtasks: newSubtasks, completed: true, completionDate: new Date().toISOString() };
+                }
+                if (!allSubtasksCompleted && task.completed) {
+                    return { ...task, subtasks: newSubtasks, completed: false, completionDate: null };
                 }
                 return { ...task, subtasks: newSubtasks };
             }
             return task;
         });
 
-        if (taskCompleted) {
+        if (attributeIdToReward) {
             const basePoints = { xp: 110, coins: 5 };
             newState.attributes = newState.attributes.map(attr => {
                  if (attr.id === attributeIdToReward) {


### PR DESCRIPTION
## Summary
- Recompute subtask completion state when toggling subtasks
- Grant XP/coins based on recalculated completion without taskCompleted flag

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a7d50964832fb0280c6994f426a8