### PR TITLE
feat: centralize color palette with CSS variables

### DIFF
--- a/src/components/AttributeCard/AttributeCard.module.css
+++ b/src/components/AttributeCard/AttributeCard.module.css
@@ -21,7 +21,7 @@
 .attributeCardLevel {
     font-size: 14px;
     font-weight: 600;
-    color: #4f46e5;
+    color: var(--color-primary);
     background-color: #eef2ff;
     padding: 4px 10px;
     border-radius: 9999px;

--- a/src/components/BottomNavBar/BottomNavBar.module.css
+++ b/src/components/BottomNavBar/BottomNavBar.module.css
@@ -41,9 +41,9 @@
     transition: color 0.2s, font-weight 0.2s;
 }
 .navItem.active .navIcon {
-    color: #4f46e5;
+    color: var(--color-primary);
 }
 .navItem.active .navText {
-    color: #4f46e5;
+    color: var(--color-primary);
     font-weight: bold;
 }

--- a/src/components/GoalCompletionCelebration/GoalCompletionCelebration.module.css
+++ b/src/components/GoalCompletionCelebration/GoalCompletionCelebration.module.css
@@ -24,7 +24,7 @@
 }
 .title {
     font-size: 28px;
-    color: #4f46e5;
+    color: var(--color-primary);
     margin: 0;
 }
 .subtitle {
@@ -49,14 +49,14 @@
     margin-top: 8px;
 }
 .rewardChip {
-    background-color: #f1f5f9;
+    background-color: var(--color-bg);
     color: #334155;
     padding: 8px 16px;
     border-radius: 9999px;
     font-weight: bold;
 }
 .continueButton {
-    background-color: #4f46e5;
+    background-color: var(--color-primary);
     color: white;
     padding: 12px 20px;
     border-radius: 9999px;

--- a/src/components/HabitActionMenu/HabitActionMenu.module.css
+++ b/src/components/HabitActionMenu/HabitActionMenu.module.css
@@ -67,7 +67,7 @@
     box-sizing: border-box;
 }
 .addButton {
-    background-color: #4f46e5;
+    background-color: var(--color-primary);
     color: white;
     font-weight: bold;
     padding: 0 16px;

--- a/src/components/HabitItem/HabitItem.module.css
+++ b/src/components/HabitItem/HabitItem.module.css
@@ -41,7 +41,7 @@
     transform: scale(0.9);
 }
 .habitCheckButtonCompleted {
-    background-color: #22c55e;
+    background-color: var(--color-primary);
     cursor: default;
 }
 .habitCheckIcon {

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -32,7 +32,7 @@
 .headerStatChip {
     display: flex;
     align-items: center;
-    background-color: #fef3c7;
+    background-color: var(--color-accent);
     padding: 8px 12px;
     border-radius: 9999px;
 }
@@ -48,7 +48,7 @@
 .headerStatTextCoins {
     margin-left: 8px;
     font-weight: bold;
-    color: #d97706;
+    color: var(--color-accent);
 }
 
 .headerStatTextTokens {

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -59,7 +59,7 @@
 .modalStepTitle {
     font-size: 18px;
     font-weight: bold;
-    color: #4f46e5;
+    color: var(--color-primary);
     margin-bottom: 16px;
     text-align: center;
 }
@@ -115,7 +115,7 @@
 }
 .primaryButton {
     flex: 1;
-    background-color: #4f46e5;
+    background-color: var(--color-primary);
     color: white;
     padding: 12px 20px;
     border-radius: 9999px;
@@ -168,7 +168,7 @@
 .addButton {
     width: 100%;
     text-align: center;
-    color: #4f46e5;
+    color: var(--color-primary);
     font-weight: 600;
     padding: 8px;
     border-radius: 8px;

--- a/src/components/ScreenHeader/ScreenHeader.module.css
+++ b/src/components/ScreenHeader/ScreenHeader.module.css
@@ -13,7 +13,7 @@
     margin: 0;
 }
 .addButton {
-    background-color: #4f46e5;
+    background-color: var(--color-primary);
     color: white;
     padding: 10px 18px;
     border-radius: 9999px;

--- a/src/components/TaskItem/TaskItem.module.css
+++ b/src/components/TaskItem/TaskItem.module.css
@@ -11,7 +11,7 @@
     transition: background-color 0.2s;
 }
 .taskItemCompleted {
-    background-color: #f1f5f9;
+    background-color: var(--color-bg);
     opacity: 0.7;
 }
 .mainContent {
@@ -32,8 +32,8 @@
     transition: all 0.2s;
 }
 .taskCheckboxCompleted {
-    background-color: #22c55e;
-    border-color: #22c55e;
+    background-color: var(--color-primary);
+    border-color: var(--color-primary);
 }
 .taskCheck {
     color: white;
@@ -77,7 +77,7 @@
 .subtaskContainer {
     padding-top: 12px;
     margin-left: 44px;
-    border-top: 1px solid #f1f5f9;
+    border-top: 1px solid var(--color-bg);
     margin-top: 12px;
 }
 .subtaskItem {

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,10 @@
+/* Paleta de cores global */
+:root {
+    --color-primary: #58cc02;
+    --color-accent: #ffd300;
+    --color-bg: #f0fdfa;
+}
+
 /* Reset Básico e Fonte */
 body {
     margin: 0;
@@ -12,7 +19,7 @@ body {
 
 /* Classes do App Container (movidas do objeto de styles) */
 .safeArea {
-    background-color: #f1f5f9;
+    background-color: var(--color-bg);
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/screens/HomeScreen.module.css
+++ b/src/screens/HomeScreen.module.css
@@ -67,7 +67,7 @@
 .allDoneContainer {
     text-align: center;
     padding: 32px 16px;
-    background-color: #f0fdf4;
+    background-color: var(--color-bg);
     border-radius: 16px;
     margin: 16px 0;
 }


### PR DESCRIPTION
## Summary
- add global CSS color variables
- apply color variables across nav bar, header, modals and other modules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a7c57638832f8661391898ab74cb