### PR TITLE
feat: add sound toggle and effects

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import GoalsScreen from './screens/GoalsScreen';
 import HabitsScreen from './screens/HabitsScreen';
 import TasksScreen from './screens/TasksScreen';
 import AttributesScreen from './screens/AttributesScreen';
+import SettingsScreen from './screens/SettingsScreen';
 
 // Import Components
 import Header from './components/Header/Header';
@@ -58,6 +59,8 @@ export default function App() {
                 return <TasksScreen onAddTask={() => onOpenModal('addTask')} />;
             case 'Atributos':
                 return <AttributesScreen onAddAttribute={() => onOpenModal('addAttribute')} onEditAttribute={(attr) => onOpenModal('editAttribute', attr)} onDeleteAttribute={(attr) => onOpenModal('deleteAttribute', attr)} />;
+            case 'Config':
+                return <SettingsScreen />;
             default:
                 return <HomeScreen setActiveScreen={setActiveScreen} setHabitActionMenu={setHabitActionMenu} />;
         }

--- a/src/assets/sounds/add.mp3
+++ b/src/assets/sounds/add.mp3
@@ -1,0 +1,1 @@
+placeholder

--- a/src/assets/sounds/complete.mp3
+++ b/src/assets/sounds/complete.mp3
@@ -1,0 +1,1 @@
+placeholder

--- a/src/assets/sounds/goal_complete.mp3
+++ b/src/assets/sounds/goal_complete.mp3
@@ -1,0 +1,1 @@
+placeholder

--- a/src/assets/sounds/step.mp3
+++ b/src/assets/sounds/step.mp3
@@ -1,0 +1,1 @@
+placeholder

--- a/src/components/BottomNavBar/BottomNavBar.jsx
+++ b/src/components/BottomNavBar/BottomNavBar.jsx
@@ -8,8 +8,9 @@ const BottomNavBar = ({ activeScreen, setActiveScreen }) => {
         { name: 'Metas', icon: '🚩' },
         { name: 'Hábitos', icon: '🔄' },
         { name: 'Tarefas', icon: '✅' },
-        { name: 'Atributos', icon: '👤' },
-    ];
+          { name: 'Atributos', icon: '👤' },
+          { name: 'Config', icon: '⚙️' },
+      ];
 
     return (
         <nav className={styles.navBarContainer}>

--- a/src/hooks/useSound.js
+++ b/src/hooks/useSound.js
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+
+import addSound from '../assets/sounds/add.mp3';
+import completeSound from '../assets/sounds/complete.mp3';
+import goalCompleteSound from '../assets/sounds/goal_complete.mp3';
+import stepSound from '../assets/sounds/step.mp3';
+
+export default function useSound() {
+  const sounds = useMemo(() => ({
+    add: new Audio(addSound),
+    complete: new Audio(completeSound),
+    goal_complete: new Audio(goalCompleteSound),
+    step: new Audio(stepSound),
+  }), []);
+
+  const play = (id) => {
+    const audio = sounds[id];
+    if (audio) {
+      audio.currentTime = 0;
+      audio.play();
+    }
+  };
+
+  return { play };
+}

--- a/src/screens/SettingsScreen.jsx
+++ b/src/screens/SettingsScreen.jsx
@@ -1,0 +1,24 @@
+// Caminho: src/screens/SettingsScreen.jsx
+import React from 'react';
+import { useData, useDispatch } from '../context/DataContext';
+
+const SettingsScreen = () => {
+  const { soundEnabled } = useData();
+  const dispatch = useDispatch();
+
+  return (
+    <div style={{ padding: '16px' }}>
+      <h2>Configurações</h2>
+      <label>
+        <input
+          type="checkbox"
+          checked={soundEnabled}
+          onChange={() => dispatch({ type: 'TOGGLE_SOUND' })}
+        />
+        Sons
+      </label>
+    </div>
+  );
+};
+
+export default SettingsScreen;


### PR DESCRIPTION
## Summary
- add reusable useSound hook and placeholder sound assets
- enable optional sound effects for data actions via DataContext
- include settings screen with toggle and navigation entry

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b17c96dc832f867d94b165b69259